### PR TITLE
Fixes the problem where elm.select2( 'val', elm.val() ) was called wit e...

### DIFF
--- a/src/select2/select2.js
+++ b/src/select2/select2.js
@@ -125,7 +125,10 @@
 
             if ( valuesFn ) {
               // watch the collection; re-evaluating it's reresentation and state every $digest
-              scope.$watch( function() { return valuesFn( scope ); }, function() {
+              scope.$watch( function() { return valuesFn( scope ); }, function( collection ) {
+                if ( !collection || !collection.length ) {
+                  return;
+                }
                 $timeout( function() {
                   elm.select2( 'val', elm.val() );
                 } );


### PR DESCRIPTION
...lm.val() equal null
