### PR TITLE
Allow valuesFn to support hash options.

### DIFF
--- a/src/select2/select2.js
+++ b/src/select2/select2.js
@@ -185,7 +185,7 @@
           if ( valuesFn ) {
             // watch the collection; re-evaluating its representation and state every $digest
             scope.$watch( function() { return valuesFn( scope ); }, function( collection ) {
-              if ( !collection || !collection.length ) {
+              if ( !collection || collection.length === 0 || angular.equals(collection, {}) ) {
                 return;
               }
               $timeout( function() {


### PR DESCRIPTION
Fixes issue #68 -- Prevents a premature return when re-evaluating the options collection value during a $digest cycle.
