### PR TITLE
Support for enable/disable in old select2 libraries

### DIFF
--- a/src/select2/select2.js
+++ b/src/select2/select2.js
@@ -115,7 +115,7 @@
         };
 
         function updateDisabled( disabled ) {
-          elm.select2( 'enable', !disabled );
+          elm.select2( disabled ? 'disable' : 'enable' );
         }
 
         function updateRequired( required ) {


### PR DESCRIPTION
The first argument to select2's enable method was not implemented until 3.4.0. Prior to that, there were simply two different methods.

If you are using ngyn's select2 along with a select2 library prior to 3.4.0, the select2's will not respect the `disabled` or `ng-disabled` values set on the original select. This change alters the way the select2 enabled is called when disabled is updated.

This has been tested to work with the 3.1.0, 3.4.1, and 3.4.5 versions of the select2 library. It can be tested here:
http://plnkr.co/edit/0x2SAwok7MqLBfOOlg0I?p=preview