### PR TITLE
Don't digest after calling elm.select2 in the valuesFn watch

### DIFF
--- a/src/select2/select2.js
+++ b/src/select2/select2.js
@@ -188,7 +188,7 @@
 
               $timeout( function() {
                 elm.select2( 'val', elm.val() );
-              } );
+              }, 0, false );
             }, true );
           }
 


### PR DESCRIPTION
Causes massive performance issues when there are lots of ngyn-select2's on a page.

This can be viewed in action here:
http://plnkr.co/edit/Wrlpe5?p=preview
This is the original performance of the same code:
http://plnkr.co/edit/VY675B?p=preview

The ngyn-select2 code is calling `elm.select2` in a `$timeout` after the values-watched collection changes. The timeout does not have `false` as the third argument, so this timeout is triggering another `$digest` for each select2. The `elm.select2` call is (as I understand it) only intended to sync the select2 indicator element with the updated collection options, and so it should a DOM-only operation. If that is correct, then this call does not need an Angular digest to occur afterward each time.

In the Plunker examples above (initializing 420 select2's), removing the digest in this timeout improved the init performance of the page from 221 seconds to 10 seconds.