### PR TITLE
[Unsaved Changes] Added space between buttons

### DIFF
--- a/src/form-saving-extensions/form-saving-extensions-form.js
+++ b/src/form-saving-extensions/form-saving-extensions-form.js
@@ -27,9 +27,17 @@ angular.module( 'ngynFormSavingExtensions' ).directive( 'form', function() {
           handlingUnsavedChanges = true;
 
           $uibModal.open( {
-            template: '<div class="modal-header"><h3>Unsaved Changes</h3></div>' +
-                      '<div class="modal-body"><p>The changes you have made have not been saved.</p><p>Are you sure you want to leave this page?</p></div>'+
-                      '<div class="modal-footer"><button class="btn btn-lg btn-primary" ng-click="$close( true )">Continue</button><button class="btn btn-link" ng-click="$close( false )">Cancel</button></div>',
+            template: '<div class="modal-header">' +
+                        '<h3>Unsaved Changes</h3>' +
+                      '</div>' +
+                      '<div class="modal-body">' +
+                        '<p>The changes you have made have not been saved.</p>' +
+                        '<p>Are you sure you want to leave this page?</p>' +
+                      '</div>'+
+                      '<div class="modal-footer">' +
+                        '<button class="btn btn-lg btn-primary" ng-click="$close( true )">Continue</button> ' +
+                        '<button class="btn btn-link" ng-click="$close( false )">Cancel</button>' +
+                      '</div>',
             controller: function() {},
             resolve: {},
             windowClass: 'modal'


### PR DESCRIPTION
The unsaved changes dialog had the buttons too close together. 

Before:
![image](https://cloud.githubusercontent.com/assets/1628649/19851358/65c7a294-9f55-11e6-9d08-a6e021eb4c24.png)

After:
![image](https://cloud.githubusercontent.com/assets/1628649/19851348/5e323184-9f55-11e6-8e55-00118882e893.png)
