### PR TITLE
Watching for class changes on the select2 element assumed class attr always existed

### DIFF
--- a/src/select2/select2.js
+++ b/src/select2/select2.js
@@ -49,7 +49,8 @@
         scope.$watch( function() {
           // keep class of the select2 in sync with the underlying select
           var container = elm.select2( 'container' );
-          var currentClass = elm.attr( 'class' );
+          // element doesn't have to have a class attribute
+          var currentClass = elm.attr( 'class' ) || '';
           var select2initialized = select2initialized || !!elm.data( 'select2' );
           if ( currentClass !== oldClass ) {
             angular.forEach( oldClass.split( ' ' ), function( c ) {


### PR DESCRIPTION
Watch function assumed that the element always had a class attribute,
which isn't neccessarily true, and certainly we have seen times when
the watch is triggered before Angular has bound attributes in, specifically in non-debug builds (which are a bit quicker) 