### PR TITLE
Support for server validation responses during batch operations

### DIFF
--- a/src/form-saving-extensions/form-saving-extensions-form.js
+++ b/src/form-saving-extensions/form-saving-extensions-form.js
@@ -164,6 +164,10 @@ angular.module( 'ngynFormSavingExtensions' ).directive( 'form', function() {
               else {
                 var isPropertyError = false;
                 ( error.propertyNames || [] ).forEach( function( propertyName ) {
+                  if ( angular.isDefined( error.entityIndex ) ) {
+                    propertyName = propertyName + '[' + error.entityIndex + ']';
+                  }
+
                   if ( ctrl.form[propertyName] ) {
                     controlsWithServerErrors.push( ctrl.form[propertyName] );
                     ctrl.form[propertyName].$setValidity( 'serverError', false );


### PR DESCRIPTION
Server validation issues can now include an `entityIndex`. This allows error messages to correctly bind to controls during batch operations. Batch form controls should carry names in the format `{propertyName}[{entityIndex}]`.