### PR TITLE
[ACE-3429] - Discard superseded requery requests.

### DIFF
--- a/src/resource-extensions/resource-extensions.js
+++ b/src/resource-extensions/resource-extensions.js
@@ -64,7 +64,7 @@
         var DEFAULT_ACTIONS = {
           'get': { method: 'GET' },
           'save': { method: 'POST' },
-          'query': { method: 'GET', isArray: true, cancellable: true },
+          'query': { method: 'GET', isArray: true },
           'remove': { method: 'DELETE' },
           'delete': { method: 'DELETE' }
         };
@@ -143,7 +143,7 @@
                 var requeryargs = injectCallback( arguments, function( data ) {
                   methodResult.length = 0;
                   angular.forEach( data, function( r ) {
-                      methodResult.push( r );
+                    methodResult.push( r );
                     } );
                 } );
 

--- a/src/resource-extensions/resource-extensions.js
+++ b/src/resource-extensions/resource-extensions.js
@@ -132,7 +132,7 @@
 
             /* jshint -W003 */
             var methodResult = oldMethod.apply( this, methodargs );
-            var previousRequery = undefined;
+            var previousRequery = methodResult;
 
             if ( action === 'query' ) {
               methodResult.requery = function() {


### PR DESCRIPTION
The order in which concurrent server requests complete is undefined; it depends
how much work the server will have to to do.
So sending "Request A" quickly followed by "Request B" could actually
result in Request B data being returned to the client before Request A data is returned.

So we have enabled the cancelling of $resource actions where the action="query", and that provides us with a method on the resource calls $cancelRequest - which will attempt to abort the HTTP request if it's in flight. If the HTTP request has already completed or previously been aborted, this is a no-op.

Tried it in Ace, and chrome debug tools report the request as being cancelled, which is nice.

Written a unit test to check if we cancel the first of a sequential set of requeries, then the callback function on the cancelled $resource requests don't get called.