### PR TITLE
Rely on teamcity environment variable to detect if running in teamcity

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,7 +181,8 @@ function runTests() {
       singleRun: true
     };
 
-    if ( process.argv.find( a => a.toLowerCase() === '--teamcity' ) ) {
+    console.log(process.env);
+    if ( process.env['TEAMCITY_VERSION'] ) {
       karmaConfig.reporters = ['teamcity'];
     }
 


### PR DESCRIPTION
The 'argv' parameter gets lost because it's initiated through `npm test`

![image](https://user-images.githubusercontent.com/1792593/56040765-0cbbef80-5d2f-11e9-818f-ac74ae15f9ab.png)
